### PR TITLE
scurve: Improve numerical stability of integration.

### DIFF
--- a/klippy/chelper/kin_extruder.c
+++ b/klippy/chelper/kin_extruder.c
@@ -33,8 +33,7 @@ extruder_integrate(struct move *m, double start, double end)
 {
     // Calculate base position and velocity with pressure advance
     double pressure_advance = m->axes_r.y;
-    double pa_add = pressure_advance * (
-            scurve_eval(&m->s, end) - scurve_eval(&m->s, start));
+    double pa_add = pressure_advance * scurve_diff(&m->s, start, end);
     double base = m->start_pos.x * (end - start);
     double integral = scurve_integrate(&m->s, start, end);
     return base + integral + pa_add;
@@ -47,9 +46,8 @@ extruder_integrate_time(struct move *m, double start, double end)
 {
     // Calculate base position and velocity with pressure advance
     double pressure_advance = m->axes_r.y;
-    double pa_add = pressure_advance * (scurve_eval(&m->s, end) * end
-            - scurve_eval(&m->s, start) * start
-            - scurve_integrate(&m->s, start, end));
+    double pa_add = pressure_advance
+        * scurve_deriv_t_integrate(&m->s, start, end);
     double base = .5 * m->start_pos.x * (end * end - start * start);
     double integral = scurve_integrate_t(&m->s, start, end);
     return base + integral + pa_add;

--- a/klippy/chelper/scurve.h
+++ b/klippy/chelper/scurve.h
@@ -22,6 +22,8 @@ void scurve_fill(struct scurve *s, int accel_order
         , double accel_t, double accel_offset_t, double total_accel_t
         , double start_accel_v, double effective_accel, double accel_comp);
 double scurve_get_time(struct scurve *s, double max_scurve_t, double distance);
+double scurve_diff(struct scurve *s, double start, double end);
+double scurve_deriv_t_integrate(struct scurve *s, double start, double end);
 double scurve_integrate(struct scurve *s, double start, double end);
 double scurve_integrate_t(struct scurve *s, double start, double end);
 


### PR DESCRIPTION
Avoid computing differences of very close numbers when computing
integrals of S-Curves: inline expressions with explicit interval length.
This improves numerical stability of integration over very small
smoothing periods.

Signed-off-by: Dmitry Butyugin <dmbutyugin@google.com>